### PR TITLE
add missing translation for untagged feeds

### DIFF
--- a/client/app/locales/en.js
+++ b/client/app/locales/en.js
@@ -100,5 +100,6 @@ module.exports = {
     "panelSettings use-quickmarks": "Use the Quickmarks app to save links",
     "panelSettings use-twitter": "Use twitter to share links",
     "panelSettings show-old-links": "Show new and old links",
-    "panelSettings use-light-colors": "Use light colors for the interface"
+    "panelSettings use-light-colors": "Use light colors for the interface",
+    "tag untagged": "untagged"
 }

--- a/client/app/locales/fr.js
+++ b/client/app/locales/fr.js
@@ -100,5 +100,6 @@ module.exports = {
     "panelSettings use-quickmarks": "Utiliser l'app Quickmarks pour sauvegarder les liens",
     "panelSettings use-twitter": "Utiliser Twitter pour partager les liens",
     "panelSettings show-old-links": "Afficher les nouveaux et les vieux liens",
-    "panelSettings use-light-colors": "Utiliser des couleurs claires pour l'interface"
+    "panelSettings use-light-colors": "Utiliser des couleurs claires pour l'interface",
+    "tag untagged": "non classé"
 }

--- a/client/app/views/templates/tag.jade
+++ b/client/app/views/templates/tag.jade
@@ -3,7 +3,10 @@
         .tag-toggle
             span(class="glyphicon glyphicon-chevron-right")
             span(class="glyphicon glyphicon-chevron-down")
-        .tag-name #{name}
+        if name == "untagged"
+            .tag-name=t("tag untagged")
+        else
+            .tag-name #{name}
         .tag-refresh
             span(class="glyphicon glyphicon-refresh")
     .tag-feeds


### PR DESCRIPTION
I realize that I forgot to translate the "untagged" category for feeds without tag.